### PR TITLE
feat: add user-wide Claude configuration and preferences

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,6 @@ This is a modular dotfiles repository for macOS configuration:
 ## Code Style & Conventions
 
 - **Shell scripts**: Use `set -euo pipefail` for error handling
-- **Git**: Commit signing enabled, verbose commits, force-with-lease for safety
 - **ZSH**: Antidote for plugin management, starship prompt, fzf integration
 - **Path**: Duplicate removal with typeset -U, custom bins in `$DOTFILES/bin`
 - **Naming**: Topic directories use lowercase, install scripts always named `install.sh`

--- a/claude/CLAUDE.md.symlink
+++ b/claude/CLAUDE.md.symlink
@@ -1,0 +1,12 @@
+# CLAUDE.md
+
+This file provides user-wide guidance to Claude Code (claude.ai/code).
+
+## General Preferences
+
+- **Branch naming**: Use simple descriptive names without prefixes (avoid feature/, bugfix/, etc.)
+- **Git**: Commit signing enabled, verbose commits, force-with-lease for safety
+- **Git identity**: If git commit fails due to missing identity, run `git-assume lox` to set default identity
+- **Shell scripts**: Use `set -euo pipefail` for error handling
+- **Dependencies**: Prefer Hermit for lox/ projects; otherwise follow repo patterns (npm/yarn for Node, etc.)
+- **Hermit**: If `bin/activate-hermit` exists, project uses Hermit for dependency management (activation handled by shell hooks)

--- a/claude/install.sh
+++ b/claude/install.sh
@@ -7,5 +7,6 @@ mkdir -p "$HOME/.claude"
 
 # Create symlinks for Claude settings
 ln -sf "$DOTFILES/claude/settings.json.symlink" "$HOME/.claude/settings.json"
+ln -sf "$DOTFILES/claude/CLAUDE.md.symlink" "$HOME/.claude/CLAUDE.md"
 
 echo "Claude settings linked successfully"

--- a/git/gitignore.symlink
+++ b/git/gitignore.symlink
@@ -7,3 +7,4 @@
 .hermit/
 .repl-history
 .aider*
+.claude/settings.local.json


### PR DESCRIPTION
- Create claude/CLAUDE.md.symlink with user-wide preferences (branch naming, git identity, Hermit usage)
- Update claude/install.sh to symlink user-wide CLAUDE.md to ~/.claude/
- Add .claude/settings.local.json to global gitignore
- Move generic preferences from project CLAUDE.md to user-wide config

🤖 Generated with [Claude Code](https://claude.ai/code)