### PR TITLE
feat: ignore CLAUDE.local.md files

### DIFF
--- a/git/gitignore.symlink
+++ b/git/gitignore.symlink
@@ -8,3 +8,4 @@
 .repl-history
 .aider*
 .claude/settings.local.json
+CLAUDE.local.md


### PR DESCRIPTION
Add CLAUDE.local.md to global gitignore to prevent local Claude configurations from being committed to repositories.

🤖 Generated with [Claude Code](https://claude.ai/code)