### PR TITLE
zsh: use ~/.zshrc template that sources dotfiles

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,9 +9,36 @@ export DOTFILES=$(pwd)
 export ICLOUD_CONFIG=~/Library/Mobile\ Documents/com\~apple\~CloudDocs/Config
 
 echo -e "\\n› Creating symlinks"
-for src in $(find `pwd` -name '*.symlink') ; do
-  ln -sfv $src "$HOME/.$(basename "${src%.*}")"
+# Symlink all *.symlink files except zshrc.symlink (handled via ~/.zshrc template)
+for src in $(find "$(pwd)" -name '*.symlink' -not -name 'zshrc.symlink') ; do
+  ln -sfv "$src" "$HOME/.$(basename "${src%.*}")"
 done
+
+echo -e "\\n› Ensuring ~/.zshrc includes dotfiles hook"
+ZSHRC_TEMPLATE_START="# Dotfiles zshrc hook (BEGIN)"
+ZSHRC_TEMPLATE_END="# Dotfiles zshrc hook (END)"
+ZSHRC_HOOK=$(cat <<'EOF'
+# Dotfiles zshrc hook (BEGIN)
+# This file is frequently modified by tools. Keep this small hook
+# which sources your real zsh configuration from the dotfiles repo.
+DOTFILES="${HOME}/.dotfiles"
+if [ -f "${DOTFILES}/zsh/zshrc.symlink" ]; then
+  # Source the repo-managed configuration
+  . "${DOTFILES}/zsh/zshrc.symlink"
+fi
+# Dotfiles zshrc hook (END)
+EOF
+)
+
+mkdir -p "$HOME"
+touch "$HOME/.zshrc"
+if ! grep -q "^${ZSHRC_TEMPLATE_START}$" "$HOME/.zshrc" 2>/dev/null; then
+  # Append the hook to the end to minimize interference with existing content
+  printf "\n%s\n%s\n" "$ZSHRC_HOOK" >> "$HOME/.zshrc"
+  echo "Appended dotfiles hook to ~/.zshrc"
+else
+  echo "~/.zshrc already contains dotfiles hook"
+fi
 
 echo -e "\\n> Installing Bundle"
 brew bundle install

--- a/zsh/zshrc.template
+++ b/zsh/zshrc.template
@@ -1,0 +1,16 @@
+# ~/.zshrc
+#
+# This is a small, tool-friendly template that sources your
+# real zsh configuration from the dotfiles repo. Many installers
+# append lines to ~/.zshrc; keeping this file minimal reduces churn.
+
+# Dotfiles zshrc hook (BEGIN)
+DOTFILES="${HOME}/.dotfiles"
+if [ -f "${DOTFILES}/zsh/zshrc.symlink" ]; then
+  # Source the repo-managed configuration
+  . "${DOTFILES}/zsh/zshrc.symlink"
+fi
+# Dotfiles zshrc hook (END)
+
+# Add any host-specific tweaks below this line.
+


### PR DESCRIPTION
- Stop symlinking `zsh/zshrc.symlink` to `~/.zshrc`
- Add a small hook to `~/.zshrc` that sources `${HOME}/.dotfiles/zsh/zshrc.symlink`
- Add `zsh/zshrc.template` as a reference/template
- Update `install.sh` to append the hook if missing

Rationale: many tools append to `~/.zshrc`. Keeping it as a minimal wrapper avoids churn while centralizing config in the repo.