### PR TITLE
ssh: fix install when iCloud ssh_config missing

### DIFF
--- a/ssh/install.sh
+++ b/ssh/install.sh
@@ -1,17 +1,22 @@
 #!/bin/sh
 
-test -d ~/.ssh || {
-	mkdir ~/.ssh
-}
+set -eu
 
-test -L ~/.ssh/config || {
-	ln -fsv "$DOTFILES"/ssh/config ~/.ssh/config
-}
+# Ensure ~/.ssh exists
+mkdir -p "$HOME/.ssh"
 
-test -f "${ICLOUD_CONFIG}/ssh_config" || {
-	touch ~/.ssh/config.private
-}
+# Link main SSH config from repo
+if [ ! -L "$HOME/.ssh/config" ]; then
+  ln -fsv "$DOTFILES/ssh/config" "$HOME/.ssh/config"
+fi
 
-test -L ~/.ssh/config.private || {
-	ln -sfv "${ICLOUD_CONFIG}/ssh_config" ~/.ssh/config.private
-}
+# Prefer iCloud-managed private config if present, otherwise create a local file
+if [ -f "${ICLOUD_CONFIG}/ssh_config" ]; then
+  ln -sfv "${ICLOUD_CONFIG}/ssh_config" "$HOME/.ssh/config.private"
+else
+  # No iCloud config: ensure a plain local file exists (replace dangling symlink if present)
+  if [ -L "$HOME/.ssh/config.private" ]; then
+    rm -f "$HOME/.ssh/config.private"
+  fi
+  [ -f "$HOME/.ssh/config.private" ] || : > "$HOME/.ssh/config.private"
+fi


### PR DESCRIPTION
Ensure ~/.ssh exists, avoid touching through dangling symlink, and create a local config.private when iCloud-managed ssh_config is not present. Adds quotes and set -eu for robustness.