### PR TITLE
vscode: add markdownlint + amp.tab.enabled (no amp.permissions)

### DIFF
--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -94,7 +94,20 @@
   "git.ignoreMissingGitWarning": true,
 
   //--------------------------------------------------
+  // Markdownlint Configuration
+  //--------------------------------------------------
+  "markdownlint.config": {
+    "MD022": false,
+    "MD033": false,
+    "MD013": false,
+    "MD032": false,
+    "MD031": false,
+    "MD040": false
+  },
+
+  //--------------------------------------------------
   // AmpCode Configuration
   //--------------------------------------------------
-  "amp.url": "https://ampcode.com/"
+  "amp.url": "https://ampcode.com/",
+  "amp.tab.enabled": true
 }


### PR DESCRIPTION
- markdownlint.config (disable common noisy rules)
- amp.tab.enabled: true
- Keeps existing amp.url and omits the previous amp.permissions block