### PR TITLE
Guard Hermit env from dotfiles PATH setup

### DIFF
--- a/zsh/main.zsh
+++ b/zsh/main.zsh
@@ -13,14 +13,17 @@ config_files=(${config_files:#$DOTFILES/zsh/main.zsh})
 # On how to set PATH in macOS:
 # https://gist.github.com/Linerre/f11ad4a6a934dcf01ee8415c9457e7b2
 
-# remove duplicate entries from $PATH
-typeset -U PATH path
-path=("$HOME/bin" "$DOTFILES/bin" "$HOME/.local/bin" "/opt/homebrew/sbin" "/opt/homebrew/bin" $path)
+# Only set up PATH if we're not in a Hermit environment
+if [[ -z "$HERMIT_ENV" ]]; then
+  # remove duplicate entries from $PATH
+  typeset -U PATH path
+  path=("$HOME/bin" "$DOTFILES/bin" "$HOME/.local/bin" $path "/opt/homebrew/sbin" "/opt/homebrew/bin")
 
-# load the path files
-for file in ${(M)config_files:#*/path.zsh} ; do
-  source $file
-done
+  # load the path files
+  for file in ${(M)config_files:#*/path.zsh} ; do
+    source $file
+  done
+fi
 
 # Lazy-load antidote and generate the static load file only when needed
 zsh_plugins=${ZDOTDIR:-$HOME}/.zsh_plugins


### PR DESCRIPTION
## Summary
- skip the dotfiles PATH bootstrap whenever HERMIT_ENV is set