### PR TITLE
Skip zshrc.symlink during install to avoid conflicts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,11 @@ export ICLOUD_CONFIG=~/Library/Mobile\ Documents/com\~apple\~CloudDocs/Config
 echo -e "\\n› Creating symlinks"
 # Symlink all *.symlink files (zsh now uses ~/.zshrc hook instead of symlink)
 for src in $(find "$(pwd)" -name '*.symlink') ; do
+  # Skip zshrc.symlink as we manage ~/.zshrc with a hook instead
+  if [[ "$(basename "$src")" == "zshrc.symlink" ]]; then
+    echo "Skipping zshrc.symlink (managed via hook)"
+    continue
+  fi
   ln -sfv "$src" "$HOME/.$(basename "${src%.*}")"
 done
 


### PR DESCRIPTION
## Summary
- Updated install.sh to skip creating symlink for zshrc.symlink
- Prevents conflicts with hook-based ~/.zshrc management

## Test plan
- [ ] Run `./install.sh` and verify zshrc.symlink is skipped
- [ ] Verify other symlinks are still created correctly
- [ ] Confirm no errors occur during installation

🤖 Generated with [Claude Code](https://claude.ai/code)