### PR TITLE
Enhance Ghostty terminal configuration

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -16,8 +16,11 @@ shell-integration = "detect"
 shell-integration-features = "ssh-env,ssh-terminfo,title"
 window-inherit-working-directory = true
 
-# Scrollback limit (128Mb)
-scrollback-limit = 134217728
+# Useful keybinds
+keybind = shift+enter=text:\n
+
+# Scrollback limit (1Gb)
+scrollback-limit = 1073741824
 
 # Quick terminal configuration
 quick-terminal-position = top


### PR DESCRIPTION
## Summary
Improve Ghostty terminal usability with enhanced keybindings and scrollback

## Changes
- Add shift+enter keybind for literal newline input (useful for multiline commands)
- Increase scrollback limit from 128MB to 1GB for longer history retention
- Organize configuration with comment sections

🤖 Generated with [Claude Code](https://claude.ai/code)