### PR TITLE
Add VSCode YAML formatting for Docker and GitHub Actions

### DIFF
--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -122,5 +122,19 @@
         "--isolated"
       ]
     }
+  },
+  "[dockercompose]": {
+    "editor.insertSpaces": true,
+    "editor.tabSize": 2,
+    "editor.autoIndent": "advanced",
+    "editor.quickSuggestions": {
+      "other": true,
+      "comments": false,
+      "strings": true
+    },
+    "editor.defaultFormatter": "redhat.vscode-yaml"
+  },
+  "[github-actions-workflow]": {
+    "editor.defaultFormatter": "redhat.vscode-yaml"
   }
 }


### PR DESCRIPTION
## Summary
Configure VSCode to properly format Docker Compose and GitHub Actions YAML files

## Changes
- Add Docker Compose file type settings with 2-space indentation
- Add GitHub Actions workflow file type settings
- Configure redhat.vscode-yaml as default formatter for both file types
- Enable quick suggestions and advanced auto-indent for better editing experience

🤖 Generated with [Claude Code](https://claude.ai/code)