### PR TITLE
feat: add sync-fork git alias

### DIFF
--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -45,6 +45,7 @@
   track = "!git branch --set-upstream-to=origin/$(git symbolic-ref --short HEAD)"
   wip = "!git add . && git commit -a --no-verify -m WIP"
   b = "!bt() { git checkout -b lox/$(date +%Y-%m-%d)-$1;}; bt"
+  sync-fork = "!git fetch upstream && git push origin upstream/main:main"
 
 [rerere]
   enabled = 1


### PR DESCRIPTION
## Summary
- Add `git sync-fork` alias for syncing fork with upstream

## Context
When working with forks, it's common to need to sync the fork's main branch with upstream. This alias simplifies that workflow by fetching from upstream and pushing upstream/main to origin/main without checking out main locally.

## Usage
```bash
git sync-fork
```

This is equivalent to:
```bash
git fetch upstream
git push origin upstream/main:main
```

## Test plan
- [x] Added alias to gitconfig.symlink
- [x] Tested alias functionality