### PR TITLE
feat: add git-lfs support

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -2,6 +2,7 @@ cask_args appdir: '/Applications'
 
 brew 'svn'
 brew 'git'
+brew 'git-lfs'
 
 # zsh
 brew 'coreutils'

--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -58,3 +58,9 @@
 
 [gpg "ssh"]
   program = /Applications/1Password.app/Contents/MacOS/op-ssh-sign
+
+[filter "lfs"]
+  smudge = git-lfs smudge -- %f
+  process = git-lfs filter-process
+  required = true
+  clean = git-lfs clean -- %f


### PR DESCRIPTION
## Summary
- Add git-lfs to Brewfile
- Configure git-lfs filter in gitconfig

## Context
Git LFS (Large File Storage) is useful for handling large binary files in repositories. This adds the necessary configuration to support git-lfs across all repos.

## Changes
- `Brewfile`: Add git-lfs package
- `git/gitconfig.symlink`: Add git-lfs filter configuration for smudge/clean operations

## Test plan
- [x] Added git-lfs to Brewfile
- [x] Added git-lfs filter configuration
- [x] Verified configuration format