### PR TITLE
fix: prefer forwarded SSH agent over 1Password agent

### DIFF
--- a/ssh/config
+++ b/ssh/config
@@ -13,6 +13,6 @@ Host *
   ForwardAgent no
   StrictHostKeyChecking=accept-new
 
-# 1Password agent
-Host *
+# 1Password agent - only when no agent is already available (e.g., from forwarding)
+Match host * exec "test -z \"$SSH_AUTH_SOCK\""
   IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"


### PR DESCRIPTION
## Summary
Use SSH `Match exec` to conditionally apply `IdentityAgent` only when `SSH_AUTH_SOCK` is not set. This enables agent forwarding while maintaining 1Password as fallback.

## Problem
`IdentityAgent` in ssh/config always overrides forwarded SSH agents. When using `ssh -A port-charlotte`, the remote machine would try to use its local 1Password agent instead of the forwarded agent, causing authentication failures:

```
sign_and_send_pubkey: signing failed for ED25519 "SSH Key" from agent: communication with agent failed
git@github.com: Permission denied (publickey)
```

## Solution
```ssh-config
Match host * exec "test -z \"$SSH_AUTH_SOCK\""
  IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
```

The `Match exec` tests if `SSH_AUTH_SOCK` is empty:
- **Empty** → Use 1Password IdentityAgent
- **Set** → Skip IdentityAgent, use existing agent (forwarded or local)

## Behavior

| Context | SSH_AUTH_SOCK | Agent Used |
|---------|--------------|------------|
| Local terminal | Set to 1Password | 1Password |
| GUI apps | Empty | 1Password |
| `ssh -A` (forwarded) | Set by SSH | Forwarded agent ✓ |
| `ssh` (no forwarding) | Empty | 1Password |

Requires OpenSSH 6.5+ (both machines have 9.8+)