### PR TITLE
fix: escape dollar sign in SSH Match exec directive

### DIFF
--- a/ssh/config
+++ b/ssh/config
@@ -13,6 +13,6 @@ Host *
   ForwardAgent no
   StrictHostKeyChecking=accept-new
 
-# 1Password agent - only when no agent is already available (e.g., from forwarding)
-Match host * exec "test -z \"$SSH_AUTH_SOCK\""
+# 1Password agent - use unless in SSH session (forwarded agent)
+Match host * exec "sh -c 'test -z \"$SSH_CONNECTION\"'"
   IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"


### PR DESCRIPTION
## Summary
Check `SSH_CONNECTION` instead of `SSH_AUTH_SOCK` to detect SSH sessions

## Problem  
The Match exec directive had quote parsing errors, and checking `SSH_AUTH_SOCK` doesn't work because macOS sets it to a default agent that lacks the necessary keys.

## Solution
Use `SSH_CONNECTION` to detect if we're in an SSH session:

```ssh-config
Match host * exec "sh -c 'test -z \"$SSH_CONNECTION\"'"
  IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
```

**Logic:**
- `SSH_CONNECTION` is **empty** → Local machine → Use 1Password
- `SSH_CONNECTION` is **set** → In SSH session → Skip 1Password, use forwarded agent

## Behavior

| Context | SSH_CONNECTION | Agent Used |
|---------|----------------|------------|
| Local machine | Empty | 1Password ✓ |
| GUI apps | Empty | 1Password ✓ |
| `ssh -A` (forwarded) | Set | Forwarded agent ✓ |

Fixes #51