### PR TITLE
fix: simplify Match exec to avoid zsh completion parsing issues

### DIFF
--- a/ssh/config
+++ b/ssh/config
@@ -14,5 +14,5 @@ Host *
   StrictHostKeyChecking=accept-new
 
 # 1Password agent - use unless in SSH session (forwarded agent)
-Match host * exec "sh -c 'test -z \"$SSH_CONNECTION\"'"
+Match host * exec "test -z $SSH_CONNECTION"
   IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"


### PR DESCRIPTION
## Summary
Simplify Match exec quoting to fix zsh completion parsing error

## Problem
The complex quoting in the Match exec directive was breaking zsh's SSH host completion:
```
zsh:1: unmatched '
Missing Match criteria for $SSH_CONNECTION\\'
```

The issue occurred because zsh's SSH completion system parses ~/.ssh/config to extract hostnames, and it couldn't handle the nested quotes in:
```ssh-config
Match host * exec "sh -c 'test -z \"$SSH_CONNECTION\"'"
```

## Solution  
Simplify to direct test command without sh -c wrapper:
```ssh-config
Match host * exec "test -z $SSH_CONNECTION"
```

This simpler form:
- Works correctly for SSH (tested with `ssh -G`)
- Doesn't break zsh completion
- Still provides the same behavior

## Behavior

| SSH_CONNECTION | Result |
|----------------|--------|
| Unset (local) | Uses 1Password IdentityAgent ✓ |
| Set (SSH session) | Skips IdentityAgent, uses forwarded agent ✓ |

Fixes the zsh completion error while maintaining agent forwarding functionality.